### PR TITLE
fix: disable live reload

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ baseurl: ""
 permalink: pretty # Do not change this, it will break all links
 timezone: America/New_York
 markdown: kramdown
-livereload: true
+livereload: false
 # port: 4400
 
 


### PR DESCRIPTION
This PR disables the live reload, which is causing a really long timeouts on production.
![image](https://github.com/user-attachments/assets/c67ccafb-35ae-4347-82bf-576b691aa850)
